### PR TITLE
Added X and Y map coordinates (#23)

### DIFF
--- a/GB/pokemon_crystal.yml
+++ b/GB/pokemon_crystal.yml
@@ -256,7 +256,8 @@ properties:
   overworld:
     mapGroup:  { type: "reference", address: 0xDCB5, size: 1, reference: "mapGroups" }
     mapNumber: { type: "int", address: 0xDCB6, size: 1 }
-    # map: { type: "reference", address: 0xDCB5, size: 2, reference: "maps" }
+    y: { type: "int", address: 0xDCB7, size: 1 }
+    x: { type: "int", address: 0xDCB8, size: 1 }
 
   roamers:
     - { type: "macro", address: 0xDFCF, macro: "roamer" }


### PR DESCRIPTION
* Added X and Y map coordinates

These are often updated right after `mapGroup` and `mapNumber`, which is useful to detect when a change to this pair of properties is completed.

* property name change