### PR TITLE
[Yellow] Added multiple overworld logic flags  (#24)

### DIFF
--- a/GB/pokemon_yellow.yml
+++ b/GB/pokemon_yellow.yml
@@ -192,16 +192,57 @@ properties:
       lastMapLocation: { type: "reference", address: 0xD365, size: 1, reference: "maps" } #test
 
   events:
-    # un-sure what this does currently, flips to true when reset is pressed
-    # debugNewGame:
-    #   unknown1: { type: "bit", address: 0xD732, position: 0 }
-    #   unknown2: { type: "bit", address: 0xD732, position: 1 }
-    #   unknown3: { type: "bit", address: 0xD732, position: 2 }
-    #   unknown4: { type: "bit", address: 0xD732, position: 3 }
-    #   unknown5: { type: "bit", address: 0xD732, position: 4 }
-    #   unknown6: { type: "bit", address: 0xD732, position: 5 }
-    #   unknown7: { type: "bit", address: 0xD732, position: 6 }
-    #   unknown8: { type: "bit", address: 0xD732, position: 7 }
+    overworldFlags:
+      countPlayTime: { type: "bit", address: 0xD732, position: 0, description: "play time being counted" }
+      debugMode:
+        type: "bit"
+        address: 0xD732
+        position: 1
+        description: |
+          Only set by the debug build. If true:
+            * skips most of Prof. Oak's speech, and uses NINTEN as the player's name and SONY as the rival's name
+            * does not have the player start in floor two of the player's house (instead sending them to [wLastMap])
+            * allows wild battles to be avoided by holding down B
+            * allows trainers to be avoided by holding down B
+            * skips Safari Zone step counter by holding down B
+            * skips the NPC who blocks Route 3 before beating Brock by holding down B
+            * skips Cerulean City rival battle by holding down B
+            * skips Pokémon Tower rival battle by holding down B
+      flyOrDungeon:
+        type: "bit"
+        address: 0xD732
+        position: 2
+        description: >
+          the target warp is a fly warp (bit 3 set or blacked out)
+          or a dungeon warp (bit 4 set)
+      flyWarp:
+        type: "bit"
+        address: 0xD732
+        position: 3
+        description: >
+          used warp pad, escape rope, dig, teleport, or fly,
+          so the target warp is a "fly warp"
+      dungeonWarp:
+        type: "bit"
+        address: 0xD732
+        position: 4
+        description: >
+          jumped into hole (Pokemon Mansion, Seafoam Islands, Victory Road)
+          or went down waterfall (Seafoam Islands),
+          so the target warp is a "dungeon warp"
+      forceBike:
+        type: "bit"
+        address: 0xD732
+        position: 5
+        description: "currently being forced to ride bike (cycling road)"
+      destinationIsBlackout:
+        type: "bit"
+        address: 0xD732
+        position: 6
+        description: >
+          map destination is [wLastBlackoutMap]
+          (usually the last used pokemon center, but could be the player's house)
+      unusedBit: { type: "bit", address: 0xD732, position: 7, description: "unused in game" }
     townMap:
       unknown1: { type: "bit", address: 0xD5F2, position: 0 }
       unknown2: { type: "bit", address: 0xD5F2, position: 1 }


### PR DESCRIPTION
* Added X and Y map coordinates

These are often updated right after `mapGroup` and `mapNumber`, which is useful to detect when a change to this pair of properties is completed.

* property name change

* [Yellow] Added multiple overworld logic flags

Some flags that were not yet inegrated into the mapper now have readable names and descriptions.

* updated property description